### PR TITLE
fixes #14 syntax issue

### DIFF
--- a/swarm-facts.yml
+++ b/swarm-facts.yml
@@ -69,7 +69,7 @@
         hostname: "{{ item }}"
         groups: swarm_manager_operational
       with_items: "{{ ansible_play_hosts | default(play_hosts) }}"
-      when: bootstrap_first_node | changed
+      when: bootstrap_first_node.changed
 
 # retrieve the swarm tokens and populate a list of ips listening on
 # the swarm port 2377

--- a/swarm.yml
+++ b/swarm.yml
@@ -73,7 +73,7 @@
         hostname: "{{ item }}"
         groups: swarm_manager_operational
       with_items: "{{ ansible_play_hosts | default(play_hosts) }}"
-      when: bootstrap_first_node | changed
+      when: bootstrap_first_node.changed
 
 # retrieve the swarm tokens and populate a list of ips listening on
 # the swarm port 2377


### PR DESCRIPTION
Not sure this repo is still maintained @nextrevision but easy fix as suggested in the issue comment:

Change:
`when: bootstrap_first_node | changed`
to this:
`when: bootstrap_first_node.changed`
